### PR TITLE
Adds Announcement entity and user details

### DIFF
--- a/Backend/NeighboutrHub/Data/Migrations/20260319151146_announcementsAdded.Designer.cs
+++ b/Backend/NeighboutrHub/Data/Migrations/20260319151146_announcementsAdded.Designer.cs
@@ -4,6 +4,7 @@ using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Data.Migrations
 {
     [DbContext(typeof(RepositoryContext))]
-    partial class RepositoryContextModelSnapshot : ModelSnapshot
+    [Migration("20260319151146_announcementsAdded")]
+    partial class announcementsAdded
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/NeighboutrHub/Data/Migrations/20260319151146_announcementsAdded.cs
+++ b/Backend/NeighboutrHub/Data/Migrations/20260319151146_announcementsAdded.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class announcementsAdded : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApartmentNumber",
+                table: "AspNetUsers",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "FirstName",
+                table: "AspNetUsers",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastName",
+                table: "AspNetUsers",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ParkingSpace",
+                table: "AspNetUsers",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Storage",
+                table: "AspNetUsers",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "Announcements",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Content = table.Column<string>(type: "nvarchar(max)", maxLength: 5000, nullable: false),
+                    Category = table.Column<int>(type: "int", nullable: false),
+                    CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Announcements", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Announcements");
+
+            migrationBuilder.DropColumn(
+                name: "ApartmentNumber",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "FirstName",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastName",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "ParkingSpace",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Storage",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Backend/NeighboutrHub/Data/RepositoryContext.cs
+++ b/Backend/NeighboutrHub/Data/RepositoryContext.cs
@@ -7,6 +7,7 @@ namespace Data;
 
 public class RepositoryContext : IdentityDbContext<AppUser>
 {
+    DbSet<Announcement> Announcements { get; set; }
     
 
     public RepositoryContext(DbContextOptions<RepositoryContext> options) : base(options)

--- a/Backend/NeighboutrHub/Entities/Helpers/AnnouncementCategory.cs
+++ b/Backend/NeighboutrHub/Entities/Helpers/AnnouncementCategory.cs
@@ -1,0 +1,9 @@
+namespace Entities.Helpers;
+
+public enum AnnouncementCategory
+{
+    Maintenance,
+    Event,
+    Policy,
+    General
+}

--- a/Backend/NeighboutrHub/Entities/Models/Announcement.cs
+++ b/Backend/NeighboutrHub/Entities/Models/Announcement.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Entities.Helpers;
+
+namespace Entities.Models;
+
+public class Announcement : IIdEntity
+{
+    [StringLength(50)]
+    public string Id { get; set; }
+    [StringLength(50)]
+    public string Title { get; set; }
+    [StringLength(5000)]
+    public string Content { get; set; }
+    public AnnouncementCategory Category { get; set; }
+    public DateTime CreatedDate { get; set; }
+
+    public Announcement()
+    {
+        Id = Guid.NewGuid().ToString();
+        CreatedDate = DateTime.Now;
+    }
+}


### PR DESCRIPTION
Introduces the `Announcement` entity to enable the creation and management of community announcements, categorized by types such as Maintenance, Event, Policy, and General.

Includes a new database migration to integrate these schema updates.

Implements #48